### PR TITLE
Bump tensorflow version to 1.13.1 - Fixes #23

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ The minimal requirements to install auDeep are listed below.
 ### Additional Requirements for GPU Support
 The `setup.py` script automatically checks if a compatible CUDA version is available on the system. If GPU support is desired, make sure that the following dependencies are installed **before** installing auDeep.
 
-- CUDA Toolkit 8.0
-- cuDNN 5.1 (optional)
+- CUDA Toolkit 10.0
+- cuDNN 7.4.1
 
 By default, the CUDA libraries are required to be available on the system path (which should be the case after a standard installation). If, for some reason, the `setup.py` script fails to detect the correct CUDA version, consider manually installing `tensorflow-gpu` 1.1.0 prior to installing auDeep.
 
@@ -42,7 +42,7 @@ These Python packages are installed automatically during setup by `pip`, and are
 - pandas
 - scipy
 - sklearn
-- tensorflow or tensorflow-gpu 1.1.0
+- tensorflow or tensorflow-gpu 1.13.0
 - xarray
 
 ## Installing in a virtualenv
@@ -79,14 +79,6 @@ If everything went well, you should see `(audeep_virtualenv)` prepended to the c
 ```
 where `auDeep` is the name of the project root directory containing the `setup.py` file. This will fetch all required depencendies and install them in the virtualenv.
 
-Once installation is complete, the TensorFlow installation within the virtualenv needs to be patched, in order to fix a bug that has not yet been resolved in the official repositories. The required changes are provided as a GNU patch file at `patches/fix_import_bug.patch` below the project root directory. To apply the patch the GNU patch utility is required, which should be installed by default on Linux systems. On Windows, it can be obtained, for example, through `cygwin`. Please note that you have to manually select the `patch` package during installation of `cygwin`, as it is not installed by default.
-```
-Linux:
-> patch audeep_virtualenv/lib/python3.5/site-packages/tensorflow/python/framework/meta_graph.py auDeep/patches/fix_import_bug.patch
-
-Windows:
-> patch .\audeep_virtualenv\Lib\site-packages\tensorflow\python\framework\meta_graph.py .\auDeep\patches\fix_import_bug.patch
-```
 This completes installation, and the toolkit CLI can be accessed through the `audeep` binary.
 ```
 > audeep --version

--- a/audeep/backend/training/base.py
+++ b/audeep/backend/training/base.py
@@ -321,11 +321,10 @@ class BaseFeatureLearningWrapper(LoggingMixin):
             The Tensorflow graph deserialized from the specified file, with any unbound inputs bound to the respective
             tensors defined in the `input_map` parameter
         """
-        input_map = {"$unbound_inputs_%s" % k: input_map[k] for k in input_map}
+        input_map = {k: input_map[k] for k in input_map}
 
         saver = tf.train.import_meta_graph(str(model_filename.with_suffix(".meta")),
-                                           clear_devices=True,
-                                           import_scope="model",
+                                           clear_devices=True, import_scope=None,
                                            input_map=input_map)
 
         return GraphWrapper(graph=tf.get_default_graph(),
@@ -352,16 +351,18 @@ class BaseFeatureLearningWrapper(LoggingMixin):
         kwargs: keyword arguments
             Additional keyword arguments specifying the model architecture
         """
-        with tf.Graph().as_default():
+        with tf.Graph().as_default() as g:
+
+
             tf_inputs = tf.placeholder(name="inputs",
                                        shape=[feature_shape[0], None, feature_shape[1]],
                                        dtype=tf.float32)
 
             self._create_model(tf_inputs, **kwargs)
 
+
             tf.train.export_meta_graph(filename=str(model_filename.with_suffix(".meta")),
-                                       export_scope="model",
-                                       clear_devices=True)
+                                       clear_devices=True, export_scope=None)
 
     def train_model(self,
                     model_filename: Path,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from subprocess import CalledProcessError, check_output
 from setuptools import setup, find_packages
 
 PROJECT = "auDeep"
-VERSION = "0.9.1"
+VERSION = "0.9.2"
 LICENSE = "GPLv3+"
 AUTHOR = "Michael Freitag"
 AUTHOR_EMAIL = "freitagm@fim.uni-passau.de"
@@ -42,7 +42,7 @@ if not tensorflow_found:
             major = int(version_string.group("major"))
             minor = int(version_string.group("minor"))
 
-            if major != 8:
+            if major != 10 or minor != 0:
                 print("detected incompatible CUDA version %d.%d" % (major, minor))
             else:
                 print("detected compatible CUDA version %d.%d" % (major, minor))
@@ -56,9 +56,9 @@ if not tensorflow_found:
         print("error during CUDA detection: %s", e)
 
     if use_gpu:
-        dependencies.append("tensorflow-gpu==1.1.0")
+        dependencies.append("tensorflow-gpu==1.13.1")
     else:
-        dependencies.append("tensorflow==1.1.0")
+        dependencies.append("tensorflow==1.13.1")
 else:
     print("tensorflow already installed, skipping CUDA detection")
 


### PR DESCRIPTION
Fixes #23 

tensorflow-1.1 is no longer available through pip. The patch also no longer seems to be required. Tested only with tutorial.